### PR TITLE
Add tests relating to lambda exclusion and boolean promotion

### DIFF
--- a/v3/test_lambda_exclusion.br
+++ b/v3/test_lambda_exclusion.br
@@ -1,0 +1,24 @@
+/*
+
+Tests for deep copy of closed variables when
+using a lambda. More specifically, deep copying
+*other* lambdas on closure. 
+
+*/
+
+
+func main() {
+    z = 0;
+    x = lambda() { z = z + 1; print(z); };
+    y = lambda() { x(); x(); };
+    y();
+    x();
+}
+
+/*
+*OUT*
+1
+2
+1
+*OUT*
+*/

--- a/v3/test_lambda_exclusion2.br
+++ b/v3/test_lambda_exclusion2.br
@@ -1,0 +1,44 @@
+/*
+
+Tests for deep copy of closed variables when
+using a lambda. More specifically, deep copying
+*other* lambdas on closure. 
+Added lambda ref param.
+
+*/
+
+func main() {
+  z = 0;
+  x = lambda() { z = z + 1; print(z); };
+  y = lambda(ref f, t) { 
+     while (t) {
+       f();
+       t = t - 1;
+     } 
+  };
+  
+  y(x, 7);
+  y(x, 10);
+}
+
+/*
+*OUT*
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+11
+12
+13
+14
+15
+16
+17
+*OUT*
+*/

--- a/v3/test_promo8.br
+++ b/v3/test_promo8.br
@@ -57,8 +57,8 @@ false
 true
 true
 false
-true
-true
+false
+false
 stuff
 stuff2
 stuff2

--- a/v3/test_promo8.br
+++ b/v3/test_promo8.br
@@ -1,0 +1,67 @@
+/*
+
+Tests coercion of bools into ints, etc.
+
+*/
+
+
+func main() {
+  print(1+true);
+  print(0&&17);
+  print(4||0);
+  print(20*true);
+  print(10/true);
+  print(false/true);
+  print(false == 0);
+  print(true == -17);
+  print(!5);
+  print(10 - true);
+  print(10 >= true * 10);
+  
+  print(true == 1);
+  print(true != 1);
+  print(true == 0);
+  print(true != 0);
+  print(false == 1);
+  print(false != 1);
+  print(false == 0);
+  print(false != 0);
+
+  print(1 == (1 + true));
+  print(1 == 2);
+  
+  if (17) { print("stuff"); }
+  x = 3;
+  while (x) { print("stuff2"); x = x - 1; }
+
+}
+
+/*
+*OUT*
+2
+false
+true
+20
+10
+0
+true
+true
+false
+9
+true
+true
+false
+false
+true
+false
+true
+true
+false
+true
+true
+stuff
+stuff2
+stuff2
+stuff2
+*OUT*
+*/


### PR DESCRIPTION
Add three tests:

`test_lambda_exclusion`: 
Tests for deep copy of closed variables when
using a lambda. More specifically, deep copying
*other* lambdas on closure.

`test_lambda_exclusion2`: 
Tests for deep copy of closed variables when
using a lambda. More specifically, deep copying
*other* lambdas on closure. 
Added lambda ref param.

`test_promo8`:
Tests coercion of bools into ints, etc.