### PR TITLE
Add test for non-captured variables in lambda

### DIFF
--- a/v3/tests/test_lambda_non_capture.br
+++ b/v3/tests/test_lambda_non_capture.br
@@ -1,0 +1,31 @@
+func foo() {
+    print("foo");
+}
+
+func bar() {
+    print("bar");
+}
+
+func main() {
+        x = lambda(ref f, ref g) {
+                print(f == g);
+                print(a == b);
+                f = g;
+                print(f == g);
+                print(a == b);
+        };
+        a = 5;
+        b = 10;
+        x(a, b);
+        print(a == b);
+}
+
+/*
+*OUT*
+false
+false
+true
+true
+true
+*OUT*
+*/


### PR DESCRIPTION
Variables initialized after lambda declaration can be accessed by the lambda by dynamic scoping rules, meaning they are not "deep-copied" but referenced, and can therefore be modified by the lambda.

Note that this doesn't violate any rules regarding captured variables (by-value), since the lambda only considers variables **initialized** after the lambda's declaration, rather than reassignment.