### PR TITLE
Nested objects and object equality testing

### DIFF
--- a/v4/tests/test_nilproto_vs_noproto.br
+++ b/v4/tests/test_nilproto_vs_noproto.br
@@ -1,0 +1,27 @@
+func main() {
+	e = @;
+	d = @;
+	c = @;
+	b = @;
+	a = @;
+	a.proto = nil;
+	b.proto = a;
+	c.proto = b;
+	d.proto = c;
+	e.proto = d;
+	protoptr = e;
+	while(protoptr != nil) {
+	    print("rah!");
+	    protoptr = protoptr.proto;
+	}
+}
+
+/*
+*OUT*
+rah!
+rah!
+rah!
+rah!
+rah!
+*OUT*
+*/

--- a/v4/tests/test_treetraversal.br
+++ b/v4/tests/test_treetraversal.br
@@ -1,0 +1,50 @@
+func Node() {
+    __out__ = @;
+    __out__.val = nil;
+    __out__.l = nil;
+    __out__.r = nil;
+    return __out__;
+}
+
+func Node(a) {
+    __out__ = @;
+    __out__.val = a;
+    __out__.l = nil;
+    __out__.r = nil;
+    return __out__;
+}
+
+func Node(a,l,r) {
+    __out__ = @;
+    __out__.val = a;
+    __out__.l = l;
+    __out__.r = r;
+    return __out__;
+}
+
+func bfs(tree) {
+    print(tree.val);
+    if (tree.l != nil) {
+        bfs(tree.l);
+    }
+    if (tree.r != nil) {
+        bfs(tree.r);
+    }
+}
+
+func main() {
+    head = Node(1, Node(2, Node(3), Node(4)), Node(5, Node(6), Node(7)));
+    bfs(head);
+}
+
+/*
+*OUT*
+1
+2
+3
+4
+5
+6
+7
+*OUT*
+*/


### PR DESCRIPTION
First commit: tests for object inequality; not sure if it was tested for or if my hacky implementation barely worked, but the test case catches an edge case that I initially passed

Second commit: Brewin# allows obj.proto ==/!= nil comparisons only if proto was defined explicitly as equaling nil; not covered in test cases